### PR TITLE
Send Binary data instead of JSON - still extract message type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ $ curl -f --no-buffer --connect-timeout 10 --silent \
         | ./rtcmMqtt
 ```
 
-N.B. rtcmMqtt publishes to a different topic for each message type (rtcm3/1077, rtcm3/1087, ...) 
+N.B. rtcmMqtt publishes to a different topic for each message type (rtcm3/1077, rtcm3/1087, ...) - subscribe to all topics using `rtcm3/#`

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ $ curl -f --no-buffer --connect-timeout 10 --silent \
         | ./rtcmMqtt
 ```
 
-N.B. rtcmMqtt publishes to a different topic for each message type (1077, 1087, ...) 
+N.B. rtcmMqtt publishes to a different topic for each message type (rtcm3/1077, rtcm3/1087, ...) 

--- a/rtcmBinMqtt.hs
+++ b/rtcmBinMqtt.hs
@@ -63,7 +63,7 @@ encodeLine :: RTCM3Msg -> (Topic, ByteString)
 encodeLine message = (msgTopic, msg)
   where
     msgTopic = toTopic $ MqttText $ Data.Text.pack msgNumber
-    msgNumber = "rtcm/" <> (BasicPrelude.drop 8 $ constrName message)
+    msgNumber = "rtcm3/" <> (BasicPrelude.drop 8 $ constrName message)
     msg = toStrict $ Binary.encode message
 
 sink :: MQTT.Config -> Sink (Topic, ByteString) IO ()

--- a/rtcmMqtt.hs
+++ b/rtcmMqtt.hs
@@ -62,7 +62,7 @@ encodeLine :: RTCM3Msg -> (Topic, ByteString)
 encodeLine message = (msgTopic, msgJson)
   where
     msgTopic = toTopic $ MqttText $ Data.Text.pack msgNumber -- assumes first 8 characters of constructor name are always RTCM3Msg
-    msgNumber = "rtcm/" <> (BasicPrelude.drop 8 $ constrName message)
+    msgNumber = "rtcm3/" <> (BasicPrelude.drop 8 $ constrName message)
     msgJson = toStrict $ encode message <> "\n"
 
 sink :: MQTT.Config -> Sink (Topic, ByteString) IO ()


### PR DESCRIPTION
Also use rtcm3/ as message topic root so you can subscribe to `rtcm3/#` for all messages.