### PR TITLE
Add EKS terraform stack

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,8 @@ in
 pkgs.stdenv.mkDerivation {
   name = "testing";
   buildInputs = with pkgs; [
+    terraform
+    aws-iam-authenticator
     google-cloud-sdk
     kubectl
     mosquitto

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,72 @@
+## Key concepts:
+
+- This code uses terraform to create an EKS Cluster and Kubernetes Worker Nodes
+    - EKS is a managed Kubernetes service
+    - the Kubernetes Worker Nodes are run on EC2 instances running in an Auto Scaling Group
+    - the Kubernetes Worker Nodes are configured with an AWS provided AMI, with a particular version of Kubernetes
+- `kubectl` command must be configured to use the EKS Cluster ($KUBECONFIG or ~/.kube/config)
+- EKS Cluster essentially functions as a job scheduler. It speaks kubernetes. Given a Kubernetes yaml, the EKS cluster will task the Worker Nodes.
+- to enable Worker Nodes to join the EKS cluster, they must configured with an IAM role
+    - EKS doesn't provide for a native way to interface between Kubernetes and IAM, so you have an extra step (`kubectl apply -f config-map-aws-auth.yaml`)
+
+
+## Terraform
+
+```
+terraform init
+terraform plan
+terraform apply
+```
+
+## Setup kubectl
+
+Setup your `KUBECONFIG`
+
+```
+terraform output kubeconfig > ~/.kube/eks-config
+export KUBECONFIG=~/.kube/eks-config
+```
+
+## Authorize worker nodes
+
+Get the config from terraform output, and save it to a yaml file:
+
+```
+terraform output config-map > config-map-aws-auth.yaml
+```
+
+Apply the config map to EKS:
+
+```
+kubectl apply -f config-map-aws-auth.yaml
+```
+
+You can verify the worker nodes are joining the cluster
+
+```
+kubectl get nodes --watch
+```
+
+## Deploy Kubernetes application
+
+Deploy the Kubernetes to the EKS cluster (to run on the Worker Nodes)
+
+```
+kubectl apply -f ../kubernetes.yaml
+```
+
+## Use application
+
+Get load balancer external DNS for HiveMQ cluster
+
+```
+kubectl get service
+```
+
+Send messages to HiveMQ using mosquitto
+
+```
+mosquitto_sub -h <loadbalancer-external-dns>.ap-southeast-2.elb.amazonaws.com -t test &
+
+mosquitto_pub -h <loadbalancer-external-dns>.ap-southeast-2.elb.amazonaws.com -t test -m "testing"
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,21 +13,18 @@
 ## Terraform
 
 ```
-terraform init
-terraform plan
-terraform apply
+./deploy-terraform.sh
 ```
 
-## Setup kubectl
+## Configure kubectl
 
-Setup your `KUBECONFIG`
+Set `$KUBECONFIG` as derived from terraform
 
 ```
-terraform output kubeconfig > ~/.kube/eks-config
-export KUBECONFIG=~/.kube/eks-config
+source init-kubeconfig.sh
 ```
 
-## Authorize worker nodes
+### Authorize worker nodes
 
 Get the config from terraform output, and save it to a yaml file:
 
@@ -41,7 +38,7 @@ Apply the config map to EKS:
 kubectl apply -f config-map-aws-auth.yaml
 ```
 
-You can verify the worker nodes are joining the cluster
+You can verify the worker nodes have joined the cluster
 
 ```
 kubectl get nodes --watch

--- a/terraform/backend.tfvars
+++ b/terraform/backend.tfvars
@@ -1,0 +1,4 @@
+bucket = "auscors-eks-terraform-state"
+dynamodb_table = "auscors-eks-terraform-state"
+key = "terraform.tfstate"
+region = "ap-southeast-2"

--- a/terraform/deploy-terraform.sh
+++ b/terraform/deploy-terraform.sh
@@ -1,0 +1,5 @@
+terraform init -backend-config=backend.tfvars
+
+terraform get
+
+terraform apply -auto-approve

--- a/terraform/init-kubeconfig.sh
+++ b/terraform/init-kubeconfig.sh
@@ -1,0 +1,5 @@
+terraform init -backend-config=backend.tfvars
+
+# setup KUBECONFIG
+terraform output kubeconfig > ~/.kube/auscors-eks-config
+export KUBECONFIG=~/.kube/auscors-eks-config

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,14 @@
+# taken from: https://github.com/WesleyCharlesBlake/terraform-aws-eks
+
+module "eks" {
+  source                    = "./modules/eks"
+  cluster-name              = "${var.cluster-name}"
+  k8s-version               = "${var.k8s-version}"
+  aws-region                = "${var.aws-region}"
+  node-instance-type        = "${var.node-instance-type}"
+  desired-capacity          = "${var.desired-capacity}"
+  max-size                  = "${var.max-size}"
+  min-size                  = "${var.min-size}"
+  vpc-subnet-cidr           = "${var.vpc-subnet-cidr}"
+  workstation-external-cidr = "${var.workstation-external-cidr}"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,14 +1,30 @@
 # taken from: https://github.com/WesleyCharlesBlake/terraform-aws-eks
 
+data "terraform_remote_state" "remote_state" {
+  backend = "s3"
+
+  config {
+    bucket         = "${var.state_bucket}"
+    dynamodb_table = "${var.state_table}"
+    region         = "${var.region}"
+    key            = "terraform.tfstate"
+  }
+}
+
+terraform {
+  backend "s3" {}
+}
+
+
 module "eks" {
   source                    = "./modules/eks"
   cluster-name              = "${var.cluster-name}"
   k8s-version               = "${var.k8s-version}"
-  aws-region                = "${var.aws-region}"
   node-instance-type        = "${var.node-instance-type}"
   desired-capacity          = "${var.desired-capacity}"
   max-size                  = "${var.max-size}"
   min-size                  = "${var.min-size}"
   vpc-subnet-cidr           = "${var.vpc-subnet-cidr}"
   workstation-external-cidr = "${var.workstation-external-cidr}"
+  region                    = "${var.region}"
 }

--- a/terraform/modules/eks/eks-cluster.tf
+++ b/terraform/modules/eks/eks-cluster.tf
@@ -1,0 +1,82 @@
+variable "workstation-external-cidr" {}
+
+resource "aws_iam_role" "cluster" {
+  name = "${var.cluster-name}-eks-cluster-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = "${aws_iam_role.cluster.name}"
+}
+
+resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSServicePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = "${aws_iam_role.cluster.name}"
+}
+
+resource "aws_security_group" "cluster" {
+  name        = "${var.cluster-name}-eks-cluster-sg"
+  description = "Cluster communication with worker nodes"
+  vpc_id      = "${aws_vpc.eks.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.cluster-name}-eks-cluster-sg"
+  }
+}
+
+resource "aws_security_group_rule" "cluster-ingress-node-https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.cluster.id}"
+  source_security_group_id = "${aws_security_group.node.id}"
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "cluster-ingress-workstation-https" {
+  cidr_blocks       = ["${var.workstation-external-cidr}"]
+  description       = "Allow workstation to communicate with the cluster API Server"
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.cluster.id}"
+  to_port           = 443
+  type              = "ingress"
+}
+
+resource "aws_eks_cluster" "eks" {
+  name     = "${var.cluster-name}"
+  role_arn = "${aws_iam_role.cluster.arn}"
+
+  vpc_config {
+    security_group_ids = ["${aws_security_group.cluster.id}"]
+    subnet_ids         = ["${aws_subnet.eks.*.id}"]
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.cluster-AmazonEKSClusterPolicy",
+    "aws_iam_role_policy_attachment.cluster-AmazonEKSServicePolicy",
+  ]
+}

--- a/terraform/modules/eks/eks-worker-nodes.tf
+++ b/terraform/modules/eks/eks-worker-nodes.tf
@@ -1,0 +1,143 @@
+variable "k8s-version" {}
+
+variable node-instance-type {}
+variable "desired-capacity" {}
+variable "max-size" {}
+variable "min-size" {}
+
+resource "aws_iam_role" "node" {
+  name = "${var.cluster-name}-eks-node-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "node-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = "${aws_iam_role.node.name}"
+}
+
+resource "aws_iam_role_policy_attachment" "node-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = "${aws_iam_role.node.name}"
+}
+
+resource "aws_iam_role_policy_attachment" "node-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = "${aws_iam_role.node.name}"
+}
+
+resource "aws_iam_instance_profile" "node" {
+  name = "${var.cluster-name}-eks-node-instance-profile"
+  role = "${aws_iam_role.node.name}"
+}
+
+resource "aws_security_group" "node" {
+  name        = "${var.cluster-name}-eks-node-sg"
+  description = "Security group for all nodes in the cluster"
+  vpc_id      = "${aws_vpc.eks.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = "${
+    map(
+     "Name", "${var.cluster-name}-eks-node-sg",
+     "kubernetes.io/cluster/${var.cluster-name}", "owned",
+    )
+  }"
+}
+
+resource "aws_security_group_rule" "node-ingress-self" {
+  description              = "Allow node to communicate with each other"
+  from_port                = 0
+  protocol                 = "-1"
+  security_group_id        = "${aws_security_group.node.id}"
+  source_security_group_id = "${aws_security_group.node.id}"
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "node-ingress-cluster" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
+  from_port                = 1025
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.node.id}"
+  source_security_group_id = "${aws_security_group.cluster.id}"
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+data "aws_ami" "eks-worker-ami" {
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-${var.k8s-version}-*"]
+  }
+
+  most_recent = true
+  owners      = ["602401143452"] # Amazon
+}
+
+# EKS currently documents this required userdata for EKS worker nodes to
+# properly configure Kubernetes applications on the EC2 instance.
+# We utilize a Terraform local here to simplify Base64 encoding this
+# information into the AutoScaling Launch Configuration.
+# More information: https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
+locals {
+  node-userdata = <<USERDATA
+#!/bin/bash
+set -o xtrace
+/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.eks.endpoint}' --b64-cluster-ca '${aws_eks_cluster.eks.certificate_authority.0.data}' '${var.cluster-name}'
+USERDATA
+}
+
+resource "aws_launch_configuration" "eks" {
+  associate_public_ip_address = true
+  iam_instance_profile        = "${aws_iam_instance_profile.node.name}"
+  image_id                    = "${data.aws_ami.eks-worker-ami.id}"
+  instance_type               = "${var.node-instance-type}"
+  name_prefix                 = "${var.cluster-name}-eks-"
+  security_groups             = ["${aws_security_group.node.id}"]
+  user_data_base64            = "${base64encode(local.node-userdata)}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "eks" {
+  desired_capacity     = "${var.desired-capacity}"
+  launch_configuration = "${aws_launch_configuration.eks.id}"
+  max_size             = "${var.max-size}"
+  min_size             = "${var.min-size}"
+  name                 = "${var.cluster-name}-eks-asg"
+  vpc_zone_identifier  = ["${aws_subnet.eks.*.id}"]
+
+  tag {
+    key                 = "Name"
+    value               = "${var.cluster-name}-eks-node"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kubernetes.io/cluster/${var.cluster-name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+}

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -1,0 +1,51 @@
+locals {
+  config-map-aws-auth = <<CONFIGMAPAWSAUTH
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+data:
+  mapRoles: |
+    - rolearn: ${aws_iam_role.node.arn}
+      username: system:node:{{EC2PrivateDNSName}}
+      groups:
+        - system:bootstrappers
+        - system:nodes
+CONFIGMAPAWSAUTH
+
+  kubeconfig = <<KUBECONFIG
+apiVersion: v1
+clusters:
+- cluster:
+    server: ${aws_eks_cluster.eks.endpoint}
+    certificate-authority-data: ${aws_eks_cluster.eks.certificate_authority.0.data}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: aws
+  name: aws
+current-context: aws
+kind: Config
+preferences: {}
+users:
+- name: aws
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      command: aws-iam-authenticator
+      args:
+        - "token"
+        - "-i"
+        - "${var.cluster-name}"
+KUBECONFIG
+}
+
+output "config-map-aws-auth" {
+  value = "${local.config-map-aws-auth}"
+}
+
+output "kubeconfig" {
+  value = "${local.kubeconfig}"
+}

--- a/terraform/modules/eks/providers.tf
+++ b/terraform/modules/eks/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = "${var.aws-region}"
+}
+
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {}

--- a/terraform/modules/eks/providers.tf
+++ b/terraform/modules/eks/providers.tf
@@ -1,7 +1,7 @@
-provider "aws" {
-  region = "${var.aws-region}"
-}
+variable "region" {}
 
-data "aws_region" "current" {}
+provider "aws" {
+  region = "${var.region}"
+}
 
 data "aws_availability_zones" "available" {}

--- a/terraform/modules/eks/vpc.tf
+++ b/terraform/modules/eks/vpc.tf
@@ -1,6 +1,5 @@
 variable "cluster-name" {}
 
-variable "aws-region" {}
 variable "vpc-subnet-cidr" {}
 
 resource "aws_vpc" "eks" {

--- a/terraform/modules/eks/vpc.tf
+++ b/terraform/modules/eks/vpc.tf
@@ -1,0 +1,54 @@
+variable "cluster-name" {}
+
+variable "aws-region" {}
+variable "vpc-subnet-cidr" {}
+
+resource "aws_vpc" "eks" {
+  cidr_block = "${var.vpc-subnet-cidr}"
+
+  tags = "${
+    map(
+     "Name", "${var.cluster-name}-eks-vpc",
+     "kubernetes.io/cluster/${var.cluster-name}", "shared",
+    )
+  }"
+}
+
+resource "aws_subnet" "eks" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "${cidrsubnet(var.vpc-subnet-cidr, 8, count.index )}"
+  vpc_id            = "${aws_vpc.eks.id}"
+
+  tags = "${
+    map(
+     "Name", "${var.cluster-name}-eks",
+     "kubernetes.io/cluster/${var.cluster-name}", "shared",
+    )
+  }"
+}
+
+resource "aws_internet_gateway" "eks" {
+  vpc_id = "${aws_vpc.eks.id}"
+
+  tags {
+    Name = "${var.cluster-name}-eks-igw"
+  }
+}
+
+resource "aws_route_table" "eks" {
+  vpc_id = "${aws_vpc.eks.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.eks.id}"
+  }
+}
+
+resource "aws_route_table_association" "eks" {
+  count = 2
+
+  subnet_id      = "${aws_subnet.eks.*.id[count.index]}"
+  route_table_id = "${aws_route_table.eks.id}"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "kubeconfig" {
+  value = "${module.eks.kubeconfig}"
+}
+
+output "config-map" {
+  value = "${module.eks.config-map-aws-auth}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,53 @@
+variable "cluster-name" {
+  default     = "auscors"
+  type        = "string"
+  description = "The name of your EKS Cluster"
+}
+
+variable "workstation-external-cidr" {
+  default     = "124.47.132.132/32"
+  type        = "string"
+  description = "The CIDR of the workstation to give access to EKS Cluster"
+}
+
+variable "aws-region" {
+  default     = "ap-southeast-2"
+  type        = "string"
+  description = "The AWS Region to deploy EKS"
+}
+
+variable "k8s-version" {
+  default     = "1.11"
+  type        = "string"
+  description = "Required K8s version"
+}
+
+variable "vpc-subnet-cidr" {
+  default     = "10.0.0.0/16"
+  type        = "string"
+  description = "The VPC Subnet CIDR"
+}
+
+variable "node-instance-type" {
+  default     = "t3.medium"
+  type        = "string"
+  description = "Worker Node EC2 instance type"
+}
+
+variable "desired-capacity" {
+  default     = 2
+  type        = "string"
+  description = "Autoscaling Desired node capacity"
+}
+
+variable "max-size" {
+  default     = 5
+  type        = "string"
+  description = "Autoscaling maximum node capacity"
+}
+
+variable "min-size" {
+  default     = 1
+  type        = "string"
+  description = "Autoscaling Minimum node capacity"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,12 +10,6 @@ variable "workstation-external-cidr" {
   description = "The CIDR of the workstation to give access to EKS Cluster"
 }
 
-variable "aws-region" {
-  default     = "ap-southeast-2"
-  type        = "string"
-  description = "The AWS Region to deploy EKS"
-}
-
 variable "k8s-version" {
   default     = "1.11"
   type        = "string"
@@ -51,3 +45,9 @@ variable "min-size" {
   type        = "string"
   description = "Autoscaling Minimum node capacity"
 }
+
+variable "state_bucket" {}
+
+variable "state_table" {}
+
+variable "region" {}


### PR DESCRIPTION
This adds a terraform stack for running AWS's Kubernetes service EKS.

There are still questions to answer:

- how to upgrade worker nodes (e.g., new kubernetes version, security patches)
Here's an example around doing upgrades: https://thinklumo.com/blue-green-node-deployment-kubernetes-eks-terraform/
- do we want to manage another cluster?
This current PR doesn't have any autoscaling or self-healing for the worker nodes. I think this article might point to an approach to this: https://aws.amazon.com/blogs/opensource/horizontal-pod-autoscaling-eks/
- perhaps we would prefer using AWS Fargate to have a fully managed solution
Fargate is pricier, but then developer time is expensive too and we won't be utilising the worker nodes fully all the time: https://www.trek10.com/blog/fargate-pricing-vs-ec2/

So there's still a lot of complexity ahead, and perhaps EKS might not be the best way. But this PR's a start.
