### PR TITLE
Add vernemq erlang plugin for auth

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -1,0 +1,32 @@
+Make sure auth plugin is built
+
+```
+$ cd vernemq_demo_plugin
+$ rebar3 compile
+```
+
+Inside docker-compose.yml, make sure `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `COGNITO_USER_POOL_ID` and `COGNITO_CLIENT_ID` are configured with appropriate values.
+
+Run VerneMQ configured to use auth plugin
+
+```
+$ docker-compose up
+```
+
+Test connection to MQTT fails without proper authorisation (unless `DOCKER_VERNEMQ_ALLOW_ANONYMOUS=off` is set, it will just allow)
+
+```
+$ mosquitto_pub -h localhost -p 1883 -t test -m test
+Connection Refused: not authorised.
+Error: The connection was refused.
+$ mosquitto_pub -h localhost -p 1883 -t test -m test -u nonexistent -P DoesN0tEx!st
+Connection Refused: not authorised.
+Error: The connection was refused.
+```
+
+Test connecting to MQTT stream with a user that exists within AWS Cognito
+
+```
+$ mosquitto_pub -h localhost -p 1883 -t test -m test -u jonathan -P P@ssword1
+$
+```

--- a/auth/docker-compose.yml
+++ b/auth/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  vernemq:
+    image: erlio/docker-vernemq
+    environment:
+        - DOCKER_VERNEMQ_ALLOW_ANONYMOUS=off
+        - DOCKER_VERNEMQ_LOG__CONSOLE__LEVEL=debug
+        - DOCKER_VERNEMQ_PLUGINS.vernemq_demo_plugin=on
+        - DOCKER_VERNEMQ_PLUGINS.vernemq_demo_plugin.path=/path/to/plugin
+        - DOCKER_VERNEMQ_PLUGINS.vmq_passwd=off
+        - DOCKER_VERNEMQ_PLUGINS.vmq_acl=off
+        - AWS_ACCESS_KEY_ID=
+        - AWS_SECRET_ACCESS_KEY=
+        - COGNITO_USER_POOL_ID=
+        - COGNITO_CLIENT_ID=
+    volumes:
+        - ./vernemq_demo_plugin/_build/default:/path/to/plugin
+    ports:
+        - 8883:8883
+        - 1883:1883
+        - 8888:8888

--- a/auth/vernemq_demo_plugin/README.md
+++ b/auth/vernemq_demo_plugin/README.md
@@ -1,0 +1,50 @@
+see `rebar.config` for dependencies on `aws-erlang` and `vernemq_dev`.
+
+compile plugin:
+
+```
+$ rebar3 compile
+```
+
+to interactive with the compiled code (and its plugins) via erlang repl:
+
+```
+$ rebar3 shell
+```
+
+make sure hackney, and its dependencies, has been fully loaded into the repl (needed for AWS API calls):
+```
+> application:ensure_all_started(hackney).
+```
+
+create an aws client (note the double angle brackets for casting strings to binary)
+```
+> Client = aws_client:make_client(<<"your-aws-key">>, <<"your-aws-secret">>, <<"ap-southeast-2">>).
+```
+
+list the available user pools (note the hashmap and the API's required 'MaxResults' field):
+```
+> aws_cognito_idp:list_user_pools(Client, #{<<"MaxResults">> => 20}, []).
+{ok,#{<<"UserPools">> =>
+          [#{<<"CreationDate">> => 1544050958.223,
+             <<"Id">> => <<"ap-southeast-2_Vr0EvkjSQ">>,
+             <<"LambdaConfig">> => #{},
+             <<"LastModifiedDate">> => 1550716104.605,
+             <<"Name">> => <<"test-pool">>}]},
+    {200,
+     [{<<"Date">>,<<"Fri, 03 May 2019 06:25:55 GMT">>},
+      {<<"Content-Type">>,<<"application/x-amz-json-1.1">>},
+      {<<"Content-Length">>,<<"154">>},
+      {<<"Connection">>,<<"keep-alive">>},
+      {<<"x-amzn-RequestId">>,
+       <<"4e705169-6d6c-11e9-b861-67e1658ea973">>}],
+     #Ref<0.3345765125.3976462337.179074>}}
+```
+
+try to initiate the authentication of a user, as an admin
+
+```
+> aws_cognito_idp:admin_initiate_auth(Client, #{<<"UserPoolId">> => <<"your-cognito-user-pool-id">>, <<"ClientId">> => <<"your-cognito-client-id">>, <<"AuthFlow">> => <<"ADMIN_NO_SRP_AUTH">>, <<"AuthParameters">> => #{<<"USERNAME">> => <<"testuser">>, <<"PASSWORD">> => <<"P@ssword01">>}}, []).
+```
+
+this will return something of the form `{ok, ..., ...}` if user is in the pool, or `{error, ..., ...}` if it is not

--- a/auth/vernemq_demo_plugin/rebar.config
+++ b/auth/vernemq_demo_plugin/rebar.config
@@ -1,0 +1,5 @@
+%%-*- mode: erlang -*-
+{deps, [
+        {vernemq_dev, {git, "git@github.com:vernemq/vernemq_dev.git", {branch, "master"}}},
+        {aws_erlang, {git, "git@github.com:aws-beam/aws-erlang.git", {branch, "master"}}}
+       ]}.

--- a/auth/vernemq_demo_plugin/src/vernemq_demo_plugin.app.src
+++ b/auth/vernemq_demo_plugin/src/vernemq_demo_plugin.app.src
@@ -1,0 +1,22 @@
+{application, vernemq_demo_plugin,
+ [
+  {description, "A simple demo Plugin for VerneMQ"},
+  {vsn, "0.0.1"},
+  {registered, []},
+  {applications, [
+                  kernel,
+                  stdlib
+                 ]},
+  {mod, { vernemq_demo_plugin_app, []}},
+  {env, [
+         %% this tells VerneMQ to look in the file 'vernemq_demo_plugin'
+         %% for the plugin hook functions. The format is:
+         %%  {ModuleName, HookName, Arity, Opts}
+         {vmq_plugin_hooks,
+          [
+           {vernemq_demo_plugin, auth_on_register, 5, []},
+           {vernemq_demo_plugin, auth_on_publish, 6, []},
+           {vernemq_demo_plugin, auth_on_subscribe, 3, []}
+          ]}
+        ]}
+ ]}.

--- a/auth/vernemq_demo_plugin/src/vernemq_demo_plugin.erl
+++ b/auth/vernemq_demo_plugin/src/vernemq_demo_plugin.erl
@@ -24,14 +24,12 @@
 auth_on_register({_IpAddr, _Port} = Peer, {_MountPoint, _ClientId} = SubscriberId, UserName, Password, CleanSession) ->
     error_logger:info_msg("auth_on_register: ~p ~p ~p ~p ~p", [Peer, SubscriberId, UserName, Password, CleanSession]),
 
-    AwsAccessKeyId = os:getenv("AWS_ACCESS_KEY_ID"),
-    AwsSecretAccessKey = os:getenv("AWS_SECRET_ACCESS_KEY"),
-    error_logger:info_msg("~p ~p", [AwsAccessKeyId, AwsSecretAccessKey]),
-    Client = aws_client:make_client(list_to_binary(AwsAccessKeyId), list_to_binary(AwsSecretAccessKey), <<"ap-southeast-2">>),
+    Client = aws_client:make_client(<<>>, <<>>, <<"ap-southeast-2">>),
 
-    UserPoolId = os:getenv("COGNITO_USER_POOL_ID"),
-    ClientId = os:getenv("COGNITO_CLIENT_ID"),
-    Login = aws_cognito_idp:admin_initiate_auth(Client, #{<<"UserPoolId">> => list_to_binary(UserPoolId), <<"ClientId">> => list_to_binary(ClientId), <<"AuthFlow">> => <<"ADMIN_NO_SRP_AUTH">>, <<"AuthParameters">> => #{<<"USERNAME">> => UserName, <<"PASSWORD">> => Password}}, []),
+    Login = aws_cognito_idp:initiate_auth(Client, #{<<"AuthFlow">> => <<"USER_PASSWORD_AUTH">>,
+                                                    <<"ClientId">> => <<"5ltsi83d284v80775qvv46l370">>,
+                                                    <<"AuthParameters">> => #{<<"USERNAME">> => UserName,
+                                                                              <<"PASSWORD">> => Password}}, []),
     case Login of
         {ok, _, _} -> ok;
         {error, _, _} -> error;

--- a/auth/vernemq_demo_plugin/src/vernemq_demo_plugin.erl
+++ b/auth/vernemq_demo_plugin/src/vernemq_demo_plugin.erl
@@ -1,0 +1,82 @@
+-module(vernemq_demo_plugin).
+
+-behaviour(auth_on_register_hook).
+-behaviour(auth_on_subscribe_hook).
+-behaviour(auth_on_publish_hook).
+
+-export([auth_on_register/5,
+         auth_on_publish/6,
+         auth_on_subscribe/3]).
+
+%% This file demonstrates the hooks you typically want to use
+%% if your plugin deals with Authentication or Authorization.
+%%
+%% All it does is:
+%%  - authenticate every user and write the log
+%%  - authorize every PUBLISH and SUBSCRIBE and write it to the log
+%%
+%% You don't need to implement all of these hooks, just the one
+%% needed for your use case.
+%%
+%% IMPORTANT:
+%%  these hook functions run in the session context
+%%
+auth_on_register({_IpAddr, _Port} = Peer, {_MountPoint, _ClientId} = SubscriberId, UserName, Password, CleanSession) ->
+    error_logger:info_msg("auth_on_register: ~p ~p ~p ~p ~p", [Peer, SubscriberId, UserName, Password, CleanSession]),
+
+    AwsAccessKeyId = os:getenv("AWS_ACCESS_KEY_ID"),
+    AwsSecretAccessKey = os:getenv("AWS_SECRET_ACCESS_KEY"),
+    error_logger:info_msg("~p ~p", [AwsAccessKeyId, AwsSecretAccessKey]),
+    Client = aws_client:make_client(list_to_binary(AwsAccessKeyId), list_to_binary(AwsSecretAccessKey), <<"ap-southeast-2">>),
+
+    UserPoolId = os:getenv("COGNITO_USER_POOL_ID"),
+    ClientId = os:getenv("COGNITO_CLIENT_ID"),
+    Login = aws_cognito_idp:admin_initiate_auth(Client, #{<<"UserPoolId">> => list_to_binary(UserPoolId), <<"ClientId">> => list_to_binary(ClientId), <<"AuthFlow">> => <<"ADMIN_NO_SRP_AUTH">>, <<"AuthParameters">> => #{<<"USERNAME">> => UserName, <<"PASSWORD">> => Password}}, []),
+    case Login of
+        {ok, _, _} -> ok;
+        {error, _, _} -> error;
+        {error, _} -> error
+    end.
+
+    %% do whatever you like with the params, all that matters
+    %% is the return value of this function
+    %%
+    %% 1. return 'ok' -> CONNECT is authenticated
+    %% 2. return 'next' -> leave it to other plugins to decide
+    %% 3. return {ok, [{ModifierKey, NewVal}...]} -> CONNECT is authenticated, but we might want to set some options used throughout the client session:
+    %%      - {mountpoint, NewMountPoint::string}
+    %%      - {clean_session, NewCleanSession::boolean}
+    %% 4. return {error, invalid_credentials} -> CONNACK_CREDENTIALS is sent
+    %% 5. return {error, whatever} -> CONNACK_AUTH is sent
+
+    %% we return 'ok'
+
+auth_on_publish(UserName, {_MountPoint, _ClientId} = SubscriberId, QoS, Topic, Payload, IsRetain) ->
+    error_logger:info_msg("auth_on_publish: ~p ~p ~p ~p ~p ~p", [UserName, SubscriberId, QoS, Topic, Payload, IsRetain]),
+    %% do whatever you like with the params, all that matters
+    %% is the return value of this function
+    %%
+    %% 1. return 'ok' -> PUBLISH is authorized
+    %% 2. return 'next' -> leave it to other plugins to decide
+    %% 3. return {ok, NewPayload::binary} -> PUBLISH is authorized, but we changed the payload
+    %% 4. return {ok, [{ModifierKey, NewVal}...]} -> PUBLISH is authorized, but we might have changed different Publish Options:
+    %%     - {topic, NewTopic::string}
+    %%     - {payload, NewPayload::binary}
+    %%     - {qos, NewQoS::0..2}
+    %%     - {retain, NewRetainFlag::boolean}
+    %% 5. return {error, whatever} -> auth chain is stopped, and message is silently dropped (unless it is a Last Will message)
+    %%
+    %% we return 'ok'
+    ok.
+
+auth_on_subscribe(UserName, ClientId, [{_Topic, _QoS}|_] = Topics) ->
+    error_logger:info_msg("auth_on_subscribe: ~p ~p ~p", [UserName, ClientId, Topics]),
+    %% do whatever you like with the params, all that matters
+    %% is the return value of this function
+    %%
+    %% 1. return 'ok' -> SUBSCRIBE is authorized
+    %% 2. return 'next' -> leave it to other plugins to decide
+    %% 3. return {error, whatever} -> auth chain is stopped, and no SUBACK is sent
+
+    %% we return 'ok'
+    ok.

--- a/auth/vernemq_demo_plugin/src/vernemq_demo_plugin_app.erl
+++ b/auth/vernemq_demo_plugin/src/vernemq_demo_plugin_app.erl
@@ -1,0 +1,16 @@
+-module(vernemq_demo_plugin_app).
+
+-behaviour(application).
+
+%% Application callbacks
+-export([start/2, stop/1]).
+
+%% ===================================================================
+%% Application callbacks
+%% ===================================================================
+
+start(_StartType, _StartArgs) ->
+    vernemq_demo_plugin_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/auth/vernemq_demo_plugin/src/vernemq_demo_plugin_sup.erl
+++ b/auth/vernemq_demo_plugin/src/vernemq_demo_plugin_sup.erl
@@ -1,0 +1,27 @@
+-module(vernemq_demo_plugin_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% Helper macro for declaring children of supervisor
+-define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% ===================================================================
+%% Supervisor callbacks
+%% ===================================================================
+
+init([]) ->
+    {ok, { {one_for_one, 5, 10}, []} }.
+

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,9 @@ let
     kubectl
     mosquitto
     go_1_12
+    erlang
+    rebar3
+    elixir
   ];
 
   env = pkgs.buildEnv {


### PR DESCRIPTION
I've added some prototyping for authenticating for vernemq using cognito as a backend.

This is a very rough idea, and is only currently in a local `docker-compose.yml` form, not in kubernetes yet (but wouldn't be hard to port over). I've mostly copy-pasted the demo erlang vernemq code - I've left in the comments for now, but will clean up.

I'm not sure how I feel about having environment variables for AWS access keys. It would require creating a dedicated IAM service account & would make rotating keys difficult.

I've started looking into [kiam](https://github.com/uswitch/kiam) and [kube2iam](https://github.com/jtblin/kube2iam) as this seems like the recommended way to go. But I haven't found a tutorial which really spells out everything required to set it up. What do you think?